### PR TITLE
Handle project strings in NLP parsing

### DIFF
--- a/src/modals/TaskCreationModal.ts
+++ b/src/modals/TaskCreationModal.ts
@@ -225,6 +225,10 @@ export class TaskCreationModal extends TaskModal {
         
         if (parsed.contexts && parsed.contexts.length > 0) this.contexts = parsed.contexts.join(', ');
         if (parsed.tags && parsed.tags.length > 0) this.tags = parsed.tags.join(', ');
+        if (parsed.projects && parsed.projects.length > 0) {
+            this.initializeProjectsFromStrings(parsed.projects);
+            this.renderProjectsList();
+        }
         if (parsed.details) this.details = parsed.details;
         if (parsed.recurrence) this.recurrenceRule = parsed.recurrence;
 


### PR DESCRIPTION
## Summary
- update `applyParsedData` in `TaskCreationModal` to load project strings
- ensure project list is rendered after parsing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68768686f1288332bcb1a56359760aba