### PR TITLE
Add projects to instant conversion

### DIFF
--- a/src/services/InstantTaskConvertService.ts
+++ b/src/services/InstantTaskConvertService.ts
@@ -4,7 +4,7 @@ import { TasksPluginParser, ParsedTaskData } from '../utils/TasksPluginParser';
 import { NaturalLanguageParser } from './NaturalLanguageParser';
 import { TaskCreationData } from '../types';
 import { getCurrentTimestamp } from '../utils/dateUtils';
-import { calculateDefaultDate } from '../utils/helpers';
+import { calculateDefaultDate, filterEmptyProjects } from '../utils/helpers';
 import { StatusManager } from './StatusManager';
 import { PriorityManager } from './PriorityManager';
 import { dispatchTaskUpdate } from '../editor/TaskLinkOverlay';
@@ -258,6 +258,7 @@ export class InstantTaskConvertService {
         let dueDate: string | undefined;
         let scheduledDate: string | undefined;
         let contextsArray: string[] = [];
+        let projectsArray: string[] = [];
         let tagsArray = [this.plugin.settings.taskTag];
         let timeEstimate: number | undefined;
         let recurrence: import('../types').RecurrenceInfo | undefined;
@@ -293,6 +294,11 @@ export class InstantTaskConvertService {
                 const defaultTagsArray = defaults.defaultTags.split(',').map(s => s.trim()).filter(s => s);
                 tagsArray = [...tagsArray, ...defaultTagsArray];
             }
+
+            // Apply projects from parsed data if available
+            if (Array.isArray(parsedData.projects)) {
+                projectsArray = filterEmptyProjects(parsedData.projects);
+            }
             
             // Apply time estimate
             if (defaults.defaultTimeEstimate && defaults.defaultTimeEstimate > 0) {
@@ -313,6 +319,9 @@ export class InstantTaskConvertService {
             scheduledDate = parsedScheduledDate || undefined;
             // Keep minimal tags (just the task tag)
             tagsArray = [this.plugin.settings.taskTag];
+            if (Array.isArray(parsedData.projects)) {
+                projectsArray = filterEmptyProjects(parsedData.projects);
+            }
         }
 
         // Create TaskCreationData object with all the data
@@ -323,6 +332,7 @@ export class InstantTaskConvertService {
             due: dueDate,
             scheduled: scheduledDate,
             contexts: contextsArray.length > 0 ? contextsArray : undefined,
+            projects: projectsArray.length > 0 ? projectsArray : undefined,
             tags: tagsArray,
             timeEstimate: timeEstimate,
             recurrence: recurrence,

--- a/tests/unit/services/InstantTaskConvertService.test.ts
+++ b/tests/unit/services/InstantTaskConvertService.test.ts
@@ -1,0 +1,39 @@
+import { InstantTaskConvertService } from '../../../src/services/InstantTaskConvertService';
+import { PluginFactory } from '../../helpers/mock-factories';
+import { TFile } from '../../__mocks__/obsidian';
+
+jest.mock('../../../src/utils/helpers', () => {
+  const actual = jest.requireActual('../../../tests/__mocks__/utils');
+  return {
+    ...actual,
+    filterEmptyProjects: jest.requireActual('../../../src/utils/helpers').filterEmptyProjects
+  };
+});
+
+jest.mock('../../../src/utils/dateUtils', () => require('../../__mocks__/utils'));
+
+describe('InstantTaskConvertService', () => {
+  it('should include projects from parsed data when creating task', async () => {
+    const mockPlugin = PluginFactory.createMockPlugin();
+    mockPlugin.settings.useDefaultsOnInstantConvert = false;
+    const service = new InstantTaskConvertService(
+      mockPlugin,
+      mockPlugin.statusManager,
+      mockPlugin.priorityManager
+    );
+
+    const parsedData: any = {
+      title: 'Test Task',
+      projects: ['[[Project One]]', 'Second Project']
+    };
+
+    (mockPlugin.taskService.createTask as jest.Mock).mockResolvedValue({ file: new TFile('Tasks/test.md') });
+
+    const file = await (service as any).createTaskFile(parsedData, '');
+
+    expect(mockPlugin.taskService.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ projects: ['[[Project One]]', 'Second Project'] })
+    );
+    expect(file).toBeInstanceOf(TFile);
+  });
+});


### PR DESCRIPTION
## Summary
- support projects field when converting tasks instantly
- test project handling in InstantTaskConvertService

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687686880c788332aad7d448e6f0127c