### PR TITLE
Update docs for NLP project syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ recurrence: "FREQ=WEEKLY;BYDAY=MO"
 complete_instances: ["2024-01-08"]
 ```
 
+### Natural Language Example
+Typing a description like:
+
+```
+Finish slides #[[Conference Prep]] tomorrow
+```
+
+will create a task linked to the project note "Conference Prep" with a due date
+set for tomorrow.
+
 ## Credits
 
 This plugin uses [FullCalendar.io](https://fullcalendar.io/) for its calendar components.

--- a/docs/features/task-management.md
+++ b/docs/features/task-management.md
@@ -10,6 +10,19 @@ TaskNotes also supports **Natural Language Creation**, which allows you to creat
 
 Additionally, you can convert existing checkbox tasks in your notes to TaskNotes using the **Instant Conversion** feature.
 
+## Natural Language
+
+The natural language parser can assign projects directly from your text. Use the
+`#[[Project Name]]` syntax to reference a project note while typing your task
+description. For example:
+
+```
+Finish landing page #[[Website Redesign]] tomorrow
+```
+
+This will link the task to the project note "Website Redesign" and set the due
+date to tomorrow.
+
 ## Task Properties
 
 Each task in TaskNotes is a Markdown file with a YAML frontmatter block that stores its properties. The core properties include:


### PR DESCRIPTION
## Summary
- document project linking syntax in Natural Language section
- show NLP example in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687686889d988332be54ab147a5bd9ff